### PR TITLE
Refactor networking module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@
 //
 import * as ec2 from '@aws-cdk/aws-ec2'
 import * as cdk from '@aws-cdk/core'
+import * as net from './net'
 import * as storage from './storage'
 import * as vault from './vault'
-import * as vpc from './vpc'
 
 //
 // PrivX Backing Service 
@@ -42,7 +42,7 @@ export class AwsRegionServices extends cdk.Stack implements Services  {
 
     const keys = vault.Secret(this)
     
-    this.vpc = vpc.Silo(this, cidr)
+    this.vpc = net.Vpc(this, cidr)
     this.storageSg = new ec2.SecurityGroup(this, 'StorageSg', { vpc: this.vpc })
 
     const db = storage.Db(this, this.vpc, this.storageSg, keys)

--- a/src/net.ts
+++ b/src/net.ts
@@ -1,7 +1,7 @@
 import * as ec2 from '@aws-cdk/aws-ec2'
 import * as cdk from '@aws-cdk/core'
 
-export const Silo = (scope: cdk.Construct, cidr: string): ec2.Vpc => {
+export const Vpc = (scope: cdk.Construct, cidr: string): ec2.Vpc => {
   if (!cidr.startsWith('10.') || !cidr.endsWith('/16')) {
     throw new Error('Please use class A network in VPC CIDR = 10.x.x.x/16.')
   }

--- a/test/net.test.ts
+++ b/test/net.test.ts
@@ -1,11 +1,11 @@
 import { expect as stackExpect, haveResource } from '@aws-cdk/assert'
 import * as cdk from '@aws-cdk/core'
-import * as vpc from '../src/vpc'
+import * as net from '../src/net'
 
 test('configure vpc', () => {
   const app = new cdk.App()
   const stack = new cdk.Stack(app, 'test', {})
-  vpc.Silo(stack, '10.0.0.0/16')
+  net.Vpc(stack, '10.0.0.0/16')
 
   const elements: string[] = [
     'AWS::EC2::VPC',
@@ -17,7 +17,7 @@ test('invalid vpc configure', () => {
   const t = () => {
     const app = new cdk.App()
     const stack = new cdk.Stack(app, 'test', {})
-    vpc.Silo(stack, '192.168.0.0/16')
+    net.Vpc(stack, '192.168.0.0/16')
   }
   expect(t).toThrow(Error)
 })


### PR DESCRIPTION
Original design had module `vpc.ts` which spawn only AWS VPC related resources. An introduction of compute nodes would require AWS ALB, etc. A new module `net.ts` is introduced to accommodate all networking gears.