### PR TITLE
Support database instance rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ In the final step, please obtain a [**license code**](https://info.ssh.com/privx
 * [Getting Started with PrivX](https://help.ssh.com/support/solutions/articles/36000194728-getting-started-with-privx)
 * Learn more about [PrivX Users and Permissions](https://help.ssh.com/support/solutions/articles/36000194730-privx-users-and-permissions)
 * Check [Online Administrator Manual](https://help.ssh.com/support/solutions/folders/36000185818)
+* Read [our playbook](doc/playbook.md) for advanced deployment and configuration use-cases.
 
 ## Bugs
 

--- a/doc/playbook.md
+++ b/doc/playbook.md
@@ -40,6 +40,48 @@ cdk destroy privx-on-aws \
 
 This process clean-up all created resources from you AWS account automatically expect RDS. You need to login to AWS console > RDS and delete database. 
 
+
 ## AWS Certificate validation timeout
 
 The deployment requires a valid AWS Certificate before it can be used with AWS ALB. This scripts automates the process of certificate provisioning. However, AWS Certificate services guarantees validation within 30 min. Usually, it happens faster but we have observed a substantial delay from the service, which causes failure of the deployment. We do recommend either try deployment later or disable certificate provisioning (see Advanced deployment).  
+
+
+## Recovery Database
+
+The project supports non destructive upgrade or database recovery. AWS RDS do not support [restore from snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html) to existing database, it always creates a new instance. This is not useful if you'd like to backup and restore PrivX database because it always requires to shutdown and spawn the stack every time when you need to restore. Instead of this complication and noticeable downtime, PrivX-On-AWS allows to the run the application with two database instances and dynamically switch the traffic between them. Let's consider the following scenario:
+
+```bash
+##
+## 1. You makes an initial deployment of PrivX.
+## It deploys a default blue version of a database.
+cdk deploy privx-on-aws ...
+
+##
+## 2. Then later, you make a database snapshot using AWS Console.
+## The recovery process creates a green version of a database from snapshot.
+cdk deploy privx-on-aws \
+  -c snapB=default \
+  -c snapG=arn:aws:rds:${AWS_REGION}:${CDK_DEFAULT_ACCOUNT}:snapshot:my-snapshot-1
+
+##
+## You deployment runs two instances of database
+##  * default (blue) created from initial deployment
+##  * recovered (green) just created from snapshot
+##
+## Database instances are accessible using domain name privx-rds.${domain}
+## A weighted Route53 CNAME records are created, use weight to switch traffic
+## from blue to green and back.
+##
+
+##
+## 3. Once, you've switched the traffic to green instance, you can dispose blue version
+cdk deploy privx-on-aws \
+  -c snapG=arn:aws:rds:${AWS_REGION}:${CDK_DEFAULT_ACCOUNT}:snapshot:my-snapshot-1
+
+##
+## 4. The database rotation process can be continue from green to blue and so on
+cdk deploy privx-on-aws \
+  -c snapG=arn:aws:rds:${AWS_REGION}:${CDK_DEFAULT_ACCOUNT}:snapshot:my-snapshot-1 \
+  -c snapB=arn:aws:rds:${AWS_REGION}:${CDK_DEFAULT_ACCOUNT}:snapshot:my-snapshot-2
+
+```

--- a/src/net.ts
+++ b/src/net.ts
@@ -175,3 +175,21 @@ export const RedirectEndpoint = (
 
   return lb
 }
+
+//
+export interface CNameProps extends dns.CnameRecordProps {
+  readonly weight: number
+  readonly identity: string
+}
+
+export const CName = (
+  scope: cdk.Construct,
+  id: string,
+  props: CNameProps,
+): dns.CnameRecord => {
+  const cname = new dns.CnameRecord(scope, id, props)
+  const cfnCName = cname.node.defaultChild as dns.CfnRecordSet
+  cfnCName.weight = props.weight
+  cfnCName.setIdentifier = props.identity
+  return cname
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -39,16 +39,50 @@ export const Db = (
   topic: sns.ITopic,
 ): rds.DatabaseInstance => {
   const db = new rds.DatabaseInstance(scope, 'Db', {
+    engine: rds.DatabaseInstanceEngine.POSTGRES,
+    instanceClass: new ec2.InstanceType('t3.small'),
+
     databaseName,
     deletionProtection: false,
     removalPolicy: cdk.RemovalPolicy.DESTROY,
-    engine: rds.DatabaseInstanceEngine.POSTGRES,
-    instanceClass: new ec2.InstanceType('t3.small'),
+
     masterUserPassword: secret.secretValueFromJson('secret'),
     masterUsername: databaseName,
+
     multiAz: false,
     vpc,
     securityGroups: [sg],
+
+    // backupRetention: cdk.Duration.days(30),
+    // deleteAutomatedBackups: false,
+  })
+  DbIncidents(scope, db, topic)
+  return db
+}
+
+export const DbClone = (
+  scope: cdk.Construct,
+  vpc: ec2.IVpc,
+  sg: ec2.ISecurityGroup,
+  topic: sns.ITopic,
+  snapshotIdentifier: string,
+): rds.DatabaseInstance => {
+  const db = new rds.DatabaseInstanceFromSnapshot(scope, 'Db', {
+    engine: rds.DatabaseInstanceEngine.POSTGRES,
+    instanceClass: new ec2.InstanceType('t3.small'),
+
+    snapshotIdentifier,
+    generateMasterUserPassword: false,
+
+    deletionProtection: false,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+
+    multiAz: false,
+    vpc,
+    securityGroups: [sg],
+
+    backupRetention: cdk.Duration.days(30),
+    deleteAutomatedBackups: false,
   })
   DbIncidents(scope, db, topic)
   return db

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -67,3 +67,27 @@ test('stack spawns required resources with custom certificate', () => {
     ].indexOf(x) == -1
   )).forEach(x => expect(stack).to(haveResource(x)))
 })
+
+test('stack spawns: blue default, green snapshot', () => {
+  const app = new cdk.App({ context: {
+    domain: 'example.com',
+    snapB: 'default',
+    snapG: 'arn:aws:rds:us-east-1:000000000000:snapshot:a',
+  }})
+  const stack = new Service(app, 'test-stack', {
+    env: { account: '000000000000', region: 'us-east-1'},
+  })
+  resources.forEach(x => expect(stack).to(haveResource(x)))
+})
+
+test('stack spawns: blue snapshot, green snapshot', () => {
+  const app = new cdk.App({ context: {
+    domain: 'example.com',
+    snapB: 'arn:aws:rds:us-east-1:000000000000:snapshot:b',
+    snapG: 'arn:aws:rds:us-east-1:000000000000:snapshot:a',
+  }})
+  const stack = new Service(app, 'test-stack', {
+    env: { account: '000000000000', region: 'us-east-1'},
+  })
+  resources.forEach(x => expect(stack).to(haveResource(x)))
+})


### PR DESCRIPTION
__WHY__

Existing implementation do not support non destructive database recovery. You have to shutdown the stack and the create it again. This process is cumber some and high cause lost of data and noticeable downtime.

This change enables hot database recovery using blue/green deployment pattern.

__WHAT__
* Use AWS Route53 CNAME to establish connection with RDS instance
* Create Database instances from snapshot
* Enable Database rotations via command line options
* Fix logger configuration 

       